### PR TITLE
Add WEP security key support

### DIFF
--- a/src/backpacks/wifi/WiFiBackpack.cpp
+++ b/src/backpacks/wifi/WiFiBackpack.cpp
@@ -100,8 +100,11 @@ bool WiFiBackpack::wifiConfig(const char *ssid, const char *passphrase) {
   bool ok = true;
   ok = ok && gs.setSecurity(GSModule::GS_SECURITY_AUTO);
   if (passphrase && *passphrase) {
+    // Setting WEP passphrase will return error if phrase isn't exactly 10 or 26 bytes
+    if (strlen(passphrase) == 26 || strlen(passphrase) == 10) {
+      ok = ok && gs.setWepPassphrase(passphrase);
+    }
     ok = ok && gs.setWpaPassphrase(passphrase);
-    ok = ok && gs.setWepPassphrase(passphrase);
   }
   ok = ok && gs.setAutoAssociate(ssid);
   // Remember these settings through a reboot


### PR DESCRIPTION
Not sure this is the best way to handle WEP right now, since there are lots of other security methods, and we're using the AUTO mode by default it seems.   But here's a start.  Let me know what you think.  (also have a pull request open in the gainspan library, here:  https://github.com/Pinoccio/library-gainspan-s2w/pull/8)
