### PR TITLE
Expose temporary flag for key()

### DIFF
--- a/src/Shell.cpp
+++ b/src/Shell.cpp
@@ -578,15 +578,20 @@ static numvar uptimeMillisSleep(void) {
 \****************************/
 
 static numvar keyMap(void) {
-  if (!checkArgs(1, F("usage: key(\"string\")"))) {
+  if (!checkArgs(1, 2, F("usage: key(\"string\")" [, temp_flag]))) {
     return 0;
   }
+  unsigned long at = 0;
   static char num[8];
+  // if the temp flag was passed
+  if(getarg(0) > 1) {
+    at = getarg(2);
+  }
   if (isstringarg(1)) {
-    return keyMap((char*)getstringarg(1), 0);
+    return keyMap((char*)getstringarg(1), at);
   }
   snprintf(num, 8, "%lu", getarg(1));
-  return keyMap(num, 0);
+  return keyMap(num, at);
 }
 
 static numvar keyFree(void) {


### PR DESCRIPTION
Exposes the (pre-existing) temporary flag for the key() command so that keys can expire as soon as the bitlash call ends.  This allows the use of temporary keys without introducing a key leak that could eventually fill the key table with no way to free them.  For example:

loop()
{
  hq.report("uptime", key(uptime.minutes));
  delay(60000);
}

would fill the key table in ~13 minutes (there's 51 default keys, and a key table max size of 64).  With this update:

loop()
{
  hq.report("uptime", key(uptime.minutes, 1));
  delay(60000);
}

would run forever since the key is freed as soon as the hq.report command ends.

Two notes: The comments in key.c indicate there was thought of having the keys time-out after a certain interval indicated by the "at" variable, but that hasn't been implemented yet.  This code may need to be tweaked if/when that happens.

Secondly, these changes will also need to be made to keyMap_int() if/when that pull-request is approved.
