### PR TITLE
Allow multiple args to hq.Report.  Fix key leak

### DIFF
--- a/src/Shell.cpp
+++ b/src/Shell.cpp
@@ -997,7 +997,7 @@ StringBuffer arg2array(int ver) {
   buf = "[";
   if(ver >= 0) buf.appendSprintf("%d,", ver);
   for (i=(ver!=0)?2:1; i<=args; i++) {
-    int key = (isstringarg(i)) ? keyMap((char*)getstringarg(i), 0) : getarg(i);
+    int key = (isstringarg(i)) ? keyMap((char*)getstringarg(i), 1) : getarg(i);
     buf.appendJsonString(keyGet(key), true);
     if(i+1 <= args) buf += ",";
   }
@@ -1898,7 +1898,7 @@ static numvar hqPrint(void) {
 }
 
 static numvar hqReport(void) {
-  if (!checkArgs(2, F("usage: hq.report(\"reportname\", \"value\")"))) {
+  if (!checkArgs(2, 255, F("usage: hq.report(\"reportname\", \"value\")[,\"value\"...]"))) {
     return 0;
   }
   const char *name = (isstringarg(1))?(const char*)getarg(1):keyGet(getarg(1));


### PR DESCRIPTION
This allows multiple arguments to be passed to hq.Report().  The functionality was all there, but the checkArgs() call at the top of hqReport() was checking for exactly 2 arguments.

Also noticed a bug in arg2array.  It was allocating a "sticky" key for each string argument but not freeing them.  I changed the "at" flag from 0 to 1 to allow keyLoop to automatically free the keys on each Bitlash loop.  hq.Report still reports the correct data but now it won't fill the key table.
