### PR TITLE
Fully stop events

### DIFF
--- a/src/Scout.h
+++ b/src/Scout.h
@@ -119,6 +119,7 @@ class PinoccioScout : public PinoccioClass {
     CallbackList<void, bool> toggleBackpackVccCallbacks;
 
     bool eventVerboseOutput;
+    bool eventsStopped;
 
     PBBP bp;
     ScoutHandler handler;

--- a/src/Shell.cpp
+++ b/src/Shell.cpp
@@ -1839,6 +1839,7 @@ static numvar hqSetAddress(void) {
 \****************************/
 
 static numvar startStateChangeEvents(void) {
+  Scout.eventsStopped = false;
   Scout.startDigitalStateChangeEvents();
   Scout.startAnalogStateChangeEvents();
   Scout.startPeripheralStateChangeEvents();
@@ -1846,6 +1847,7 @@ static numvar startStateChangeEvents(void) {
 }
 
 static numvar stopStateChangeEvents(void) {
+  Scout.eventsStopped = true;
   Scout.stopDigitalStateChangeEvents();
   Scout.stopAnalogStateChangeEvents();
   Scout.stopPeripheralStateChangeEvents();
@@ -1867,6 +1869,7 @@ static numvar setEventVerbose(void) {
 \****************************/
 
 static void digitalPinEventHandler(uint8_t pin, int16_t value, int8_t mode) {
+  if(Scout.eventsStopped) return;
   uint32_t time = millis();
   char buf[16];
   
@@ -1898,6 +1901,7 @@ static void digitalPinEventHandler(uint8_t pin, int16_t value, int8_t mode) {
 }
 
 static void analogPinEventHandler(uint8_t pin, int16_t value, int8_t mode) {
+  if(Scout.eventsStopped) return;
   uint32_t time = millis();
   char buf[16];
 
@@ -1917,6 +1921,7 @@ static void analogPinEventHandler(uint8_t pin, int16_t value, int8_t mode) {
 }
 
 static void batteryPercentageEventHandler(uint8_t value) {
+  if(Scout.eventsStopped) return;
   uint32_t time = millis();
   char buf[24];
   char *func = "on.battery.level";
@@ -1936,6 +1941,7 @@ static void batteryPercentageEventHandler(uint8_t value) {
 }
 
 static void batteryChargingEventHandler(uint8_t value) {
+  if(Scout.eventsStopped) return;
   uint32_t time = millis();
   char buf[28];
   char *func = "on.battery.charging";
@@ -1955,6 +1961,7 @@ static void batteryChargingEventHandler(uint8_t value) {
 }
 
 static void temperatureEventHandler(int8_t tempC, int8_t tempF) {
+  if(Scout.eventsStopped) return;
   uint32_t time = millis();
   char buf[28];
   char *func = "on.temperature";
@@ -1974,6 +1981,7 @@ static void temperatureEventHandler(int8_t tempC, int8_t tempF) {
 }
 
 static void ledEventHandler(uint8_t redValue, uint8_t greenValue, uint8_t blueValue) {
+  if(Scout.eventsStopped) return;
   ledReportHQ();
 }
 


### PR DESCRIPTION
Some still ran, this makes events.stop stop all events that trigger reports (like led changes)
