### PR TITLE
Modules2

### DIFF
--- a/src/modules/Servo/TimerThree.h
+++ b/src/modules/Servo/TimerThree.h
@@ -26,9 +26,9 @@
 #define TIMER1_A_PIN   11
 #define TIMER1_B_PIN   12
 #define TIMER1_C_PIN   13
-#define TIMER3_A_PIN   5
-#define TIMER3_B_PIN   2
-#define TIMER3_C_PIN   3
+#define TIMER3_A_PIN   3
+#define TIMER3_B_PIN   4
+#define TIMER3_C_PIN   5
 #define TIMER4_A_PIN   6
 #define TIMER4_B_PIN   7
 #define TIMER4_C_PIN   8


### PR DESCRIPTION
Finally got back to looking at why servo (still dont love calling this servo over timer) didnt work for me. The pins are mislabled. It was moving pin 5 when using

``` cpp
 servo.pwm(3, 50); 
```

Of note, I figured it out by making a debug function to dump all Timer3 registers. Perhaps some debug would be useful to include standard for modules?

``` cpp
void dumpTimer(void) {
sp("WGM33: ");speol(WGM33);
sp("WGM32: ");speol(WGM32);
sp("WGM30: ");speol(WGM30);
sp("TCCR3A: ");speol(TCCR3A);
sp("TCCR3B: ");speol(TCCR3B);
sp("TCCR3C: ");speol(TCCR3C);
sp("TCNT3L: ");speol(TCNT3L);
sp("TCNT3H: ");speol(TCNT3H);
sp("OCR3AL: ");speol(OCR3AL);
sp("OCR3AH: ");speol(OCR3AH);
sp("OCR3BH: ");speol(OCR3BH);
sp("OCR3BL: ");speol(OCR3BL);
sp("OCR3CH: ");speol(OCR3CH);
sp("OCR3CL: ");speol(OCR3CL);
sp("ICR3H: ");speol(ICR3H);
sp("ICR3L: ");speol(ICR3L);
sp("TIMSK3: ");speol(TIMSK3);
sp("TIFR3: ");speol(TIFR3);
}
```
