### PR TITLE
Implement wifi.setverbose

### DIFF
--- a/src/backpacks/wifi/WifiBackpack.cpp
+++ b/src/backpacks/wifi/WifiBackpack.cpp
@@ -131,6 +131,7 @@ bool WifiBackpack::setup(BackpackInfo *info) {
   gs.onAssociate = onAssociate;
   gs.eventData = this;
 
+  setVerbose(false);
   if (info->id.revision == 0x11) {
     if (!gs.begin(7, 5)) {
       return false;
@@ -304,6 +305,13 @@ bool WifiBackpack::wakeUp() {
 
 bool WifiBackpack::printTime(Print &p) {
   return runDirectCommand(p, "AT+GETTIME=?");
+}
+
+void WifiBackpack::setVerbose(bool flag) {
+  if (flag)
+    gs.setLogOutput(&Serial, &Serial);
+  else
+    gs.setLogOutput(&Serial, NULL);
 }
 
 /* commands for auto-config

--- a/src/backpacks/wifi/WifiBackpack.h
+++ b/src/backpacks/wifi/WifiBackpack.h
@@ -54,6 +54,8 @@ namespace pinoccio {
       bool goToSleep();
       bool wakeUp();
 
+      void setVerbose(bool flag);
+
       GSTcpClient client;
 
       uint16_t apConnCount;

--- a/src/backpacks/wifi/WifiModule.cpp
+++ b/src/backpacks/wifi/WifiModule.cpp
@@ -215,7 +215,10 @@ static numvar wifiWakeup(void) {
 }
 
 static numvar wifiVerbose(void) {
-  // TODO
+  if (!checkArgs(1, F("usage: wifi.verbose(flag)"))) {
+    return 0;
+  }
+  WifiModule::instance.bp()->setVerbose(getarg(1));
   return 1;
 }
 


### PR DESCRIPTION
By default, only errors are logged. By running `wifi.verbose(1)`, all
data sent to and received from the wifi module is logged.

Logging only happens to Serial, since it is a bad idea to log data to HQ
(which goes through wifi, causing more log output, causing more traffic,
etc.).
