### PR TITLE
wifi: Use SPI transactions

### DIFF
--- a/src/backpacks/wifi/WifiBackpack.cpp
+++ b/src/backpacks/wifi/WifiBackpack.cpp
@@ -125,9 +125,6 @@ bool WifiBackpack::setup(BackpackInfo *info) {
   apConnCount = 0;
   connectedAt = 0;
 
-  SPI.begin();
-  SPI.setClockDivider(SPI_CLOCK_DIV16);
-
   gs.onAssociate = onAssociate;
   gs.eventData = this;
 


### PR DESCRIPTION
The Gainspan module now takes care of initializing SPI and uses the
transaction API to set the speed. We just use its defaults, so no need
to pass any extra settings either.

This new API makes sure that we always use our own SPI settings for
every transaction, even when other libraries also use the SPI bus with
different settings.

Since we always use the transaction API, this means Arduino 1.5.8 or
above is now required.
