### PR TITLE
In Shell.eval, add quotes around float values

### DIFF
--- a/src/Shell.h
+++ b/src/Shell.h
@@ -154,7 +154,7 @@ numvar PinoccioShell::eval(Print *out, const String &cmd, const Args&... args...
   StringBuffer buf(128);
   buf.concat(cmd);
   buf.concat('(');
-  Concatenator<QuoteStringsOnly>::concat(buf, ',', args...);
+  Concatenator<QuoteStringsAndFloats>::concat(buf, ',', args...);
   buf.concat(')');
   // This calls the no-argument version below, which just runs the
   // command

--- a/src/util/Concatenator.h
+++ b/src/util/Concatenator.h
@@ -50,7 +50,7 @@ struct ValueToString {
 template <typename Value>
 struct ValueToQuotedString {
   static void append(String &buf, Value value) {
-    String escaped = value;
+    String escaped(value);
     escaped.replace("\"","\\\"");
     buf.concat('"');
     buf.concat(escaped);
@@ -65,6 +65,9 @@ template <> struct QuoteStringsOnly<const char*> : ValueToQuotedString<const cha
 template <> struct QuoteStringsOnly<char*> : ValueToQuotedString<char*> {};
 template <> struct QuoteStringsOnly<String> : ValueToQuotedString<String> {};
 template <> struct QuoteStringsOnly<char> : ValueToQuotedString<char> {};
+
+template <typename Value> struct QuoteStringsAndFloats : QuoteStringsOnly<Value> {};
+template <> struct QuoteStringsAndFloats<float> : ValueToQuotedString<float> {};
 
 // Class to concatenate stuff. Use it by calling the static concat
 // method on it. For example,


### PR DESCRIPTION
Since bitlash does not understand floats, it gets confused with the dot.
By adding quotes around the rendered float, it can at least be processed
(e.g. in a custom report).
