### PR TITLE
Fix setting DNS server using `wifi.static`

### DIFF
--- a/src/backpacks/wifi/WifiModule.cpp
+++ b/src/backpacks/wifi/WifiModule.cpp
@@ -133,7 +133,7 @@ static numvar wifiStatic(void) {
     return 0;
   }
 
-  if (!GSCore::parseIpAddress(&dns, (const char *)getstringarg(3))) {
+  if (!GSCore::parseIpAddress(&dns, (const char *)getstringarg(4))) {
     speol(F("Error: Invalid dns server"));
     return 0;
   }


### PR DESCRIPTION
Before, the gateway address passed to `wifi.static` was used as both the
gateway and dns server address. The dns server address given was
ignored. This broke setups where the gateway is not also a DNS server.
