### PR TITLE
Fix power.sleep when trying to sleep > 4294 seconds

### DIFF
--- a/src/SleepHandler.h
+++ b/src/SleepHandler.h
@@ -40,7 +40,7 @@ class SleepHandler {
     // 2^32 * 16 / 1000 == 68,719,476 ms (±19 hours). ms should not be
     // bigger than that.
     static uint32_t msToTicks(uint32_t ms) {
-      return ms * 1000 / US_PER_TICK;
+      return ms / US_PER_TICK * 1000 + ms % US_PER_TICK * 1000 / US_PER_TICK;
     }
     static uint32_t usToTicks(uint32_t us) {
       return us / US_PER_TICK;


### PR DESCRIPTION
Due to an overflow in `SleepHandler::msToTicks()`, running `power.sleep` with a value of 4294968 ms or above would result in a significantly shorter sleep than requested. This is now fixed, sleeping should work up to 68719476 ms (19 hours) again, as documented.

Closes: #220
