### PR TITLE
add energy detection and a survey

### DIFF
--- a/src/modules/sniffer/SnifferModule.cpp
+++ b/src/modules/sniffer/SnifferModule.cpp
@@ -11,6 +11,11 @@
 #include "SnifferModule.h"
 
 #include <lwm/phy/atmegarfr2.h>
+#include "Scout.h"
+
+#include "util/StringBuffer.h"
+#include "util/String.h"
+#include "util/PrintToString.h"
 
 using namespace pinoccio;
 
@@ -179,8 +184,36 @@ static numvar start() {
   return 1;
 }
 
+static numvar ed() {
+  return PHY_EdReq();
+}
+
+static numvar survey() {
+  StringBuffer out(200);
+
+  for (uint8_t i = 11; i <= 26; i++){
+    PHY_SetChannel(i);
+
+    int8_t max = -90;
+    for (uint8_t j = 0; j <= 254; j++){
+      int8_t reading = PHY_EdReq();
+      if(max < reading){
+        max = reading;
+      }
+    }
+
+    out.appendSprintf("Ch: %d\t%d\r\n", i, max);
+  }
+
+  PHY_SetChannel(Scout.getChannel());
+  speol(out.c_str());
+  return 1;
+}
+
 bool SnifferModule::enable() {
   Shell.addFunction("sniffer.start", start);
+  Shell.addFunction("sniffer.ed", ed);
+  Shell.addFunction("sniffer.survey", survey);
 
   return true;
 }


### PR DESCRIPTION
Fighting some really bad range right now and wanted to a field survey to see what was up. Atmel seems to do n seconds per channel I think? I was too lazy to implement that though Im open to it. I played with taking an n in for the number of readings to take per channel, but I think thats a max 8 bit integer, it was crashing on 254, and Im worried about locking up the pinoccio loop so Im doing an arbitrary 254 readings per channel.

Let me know if you dont think this fits in your sniffer module @matthijskooijman 

Requires https://github.com/Pinoccio/library-atmel-lwm/pull/4
```
> module.enable("sniffer")
> sniffer.survey
Ch: 11  -90
Ch: 12  -85
Ch: 13  -90
Ch: 14  -90
Ch: 15  -90
Ch: 16  -88
Ch: 17  -81
Ch: 18  -90
Ch: 19  -90
Ch: 20  -90
Ch: 21  -90
Ch: 22  -63
Ch: 23  -90
Ch: 24  -83
Ch: 25  -90
Ch: 26  -90

> print sniffer.ed
-90
> 
```