### PR TITLE
move radio sleep out to seperate function

### DIFF
--- a/src/Scout.cpp
+++ b/src/Scout.cpp
@@ -149,8 +149,7 @@ void PinoccioScout::setup(const char *sketchName, const char *sketchRevision, in
 void PinoccioScout::loop() {
   now = SleepHandler::uptime().seconds;
 
-  bool canSleep = true;
-  // TODO: Let other loop functions return some "cansleep" status as well
+  // TODO: Let other loop functions return some "cansleep" status
 
   PinoccioClass::loop();
 
@@ -180,7 +179,8 @@ void PinoccioScout::loop() {
   handler.loop();
   ModuleHandler::loop();
   Backpacks::loop();
-
+  SleepHandler::loop();
+  
   if(showStatus)
   {
     Led.setRedValue(Led.getRedValue());
@@ -189,14 +189,14 @@ void PinoccioScout::loop() {
   }
 
   if (sleepPending) {
-    canSleep = canSleep && !NWK_Busy();
-
     // if remaining <= 0, we won't actually sleep anymore, but still
     // call doSleep to run the callback and clean up
-    if (SleepHandler::scheduledTicksLeft() == 0)
+    if (SleepHandler::scheduledTicksLeft() == 0){
       doSleep(true);
-    else if (canSleep)
+    }
+    else{
       doSleep(false);
+    }
   }
 }
 
@@ -664,12 +664,8 @@ void PinoccioScout::doSleep(bool pastEnd) {
   sleepPending = false;
 
   if (!pastEnd) {
-    NWK_SleepReq();
-
     // TODO: suspend more stuff? Wait for UART byte completion?
-
     SleepHandler::doSleep(true);
-    NWK_WakeupReq();
   }
 
   // TODO: Allow ^C to stop running callbacks like this one

--- a/src/Shell.cpp
+++ b/src/Shell.cpp
@@ -253,6 +253,14 @@ static numvar uptimeSleepingSeconds(void) {
   return SleepHandler::sleeptime().seconds;
 }
 
+static numvar uptimeMeshSleepingMicros(void) {
+  return SleepHandler::meshsleeptime().us;
+}
+
+static numvar uptimeMeshSleepingSeconds(void) {
+  return SleepHandler::meshsleeptime().seconds;
+}
+
 static numvar uptimeMicros(void) {
   return SleepHandler::uptime().us;
 }
@@ -275,6 +283,16 @@ static void appendTime(StringBuffer &b, Duration d) {
 
   b.appendSprintf("%u days, %u hours, %u minutes, %d.%06lu seconds",
                   days, hours, minutes, seconds, d.us);
+}
+
+static numvar powerSleepRadio(void) {
+  if (!getarg(0) || getarg(0) > 2) {
+    speol("usage: power.sleep2(ms)");
+    return 0;
+  }
+  uint32_t ms = getarg(1);
+  SleepHandler::sleepRadio(ms);
+  return 1;
 }
 
 static numvar uptimeStatus(void) {
@@ -2396,6 +2414,7 @@ void PinoccioShell::setup() {
   addFunction("power.sleep", powerSleep);
   addFunction("power.report", powerReport);
   addFunction("power.wakeup.pin", powerWakeupPin);
+  addFunction("power.sleep2", powerSleepRadio);
 
   addFunction("mesh.config", meshConfig);
   addFunction("mesh.setchannel", meshSetChannel);
@@ -2450,6 +2469,9 @@ void PinoccioShell::setup() {
   addFunction("uptime.getlastreset", getLastResetCause);
   addFunction("uptime.status", uptimeStatus);
   addFunction("uptime", uptimeStatus);
+
+  addFunction("uptime.meshsleeping.micros", uptimeMeshSleepingMicros);
+  addFunction("uptime.meshsleeping.seconds", uptimeMeshSleepingSeconds);
 
   addFunction("led.on", ledTorch); // alias
   addFunction("led.off", ledOff);

--- a/src/SleepHandler.cpp
+++ b/src/SleepHandler.cpp
@@ -4,12 +4,26 @@
 #include "SleepHandler.h"
 
 static volatile bool timer_match;
+static volatile bool mesh_timer_match;
+
 Duration SleepHandler::lastOverflow = {0, 0};
 Duration SleepHandler::totalSleep = {0, 0};
+Duration SleepHandler::meshSleep = {0, 0};
+uint32_t SleepHandler::meshSleepStart = 0;
+
+// Returns the time mesh slept since startup
+const Duration& SleepHandler::meshsleeptime() {
+  return meshSleep;
+}
+
 Pbbe::LogicalPin::mask_t SleepHandler::pinWakeups = 0;
 
 ISR(SCNT_CMP3_vect) {
   timer_match = true;
+}
+
+ISR(SCNT_CMP2_vect) {
+  mesh_timer_match = true;
 }
 
 ISR(SCNT_OVFL_vect) {
@@ -48,7 +62,16 @@ void SleepHandler::write_scocr3(uint32_t val) {
   SCOCR3LL = val;
 }
 
+void SleepHandler::write_scocr2(uint32_t val) {
+  // Write LL last, that will update the entire register atomically
+  SCOCR2HH = val >> 24;
+  SCOCR2HL = val >> 16;
+  SCOCR2LH = val >> 8;
+  SCOCR2LL = val;
+}
+
 void SleepHandler::setup() {
+
   // Enable asynchronous mode for timer2. This is required to start the
   // 32kiHz crystal at all, so we can use it for the symbol counter. See
   // http://www.avrfreaks.net/index.php?name=PNphpBB2&file=viewtopic&t=142962
@@ -71,6 +94,15 @@ void SleepHandler::setup() {
   // Enable the pin change interrupt 0 (for PCINT0-7). Individual pins
   // remain disabled until we actually sleep.
   PCICR |= (1 << PCIE0);
+}
+
+void SleepHandler::loop() {
+  if (mesh_timer_match) {
+    uint32_t after = read_sccnt();
+    meshSleep += (uint64_t)(after - meshSleepStart) * US_PER_TICK;
+    NWK_WakeupReq();
+    mesh_timer_match = false;
+  }
 }
 
 // Sleep until the timer match interrupt fired. If interruptible is
@@ -145,6 +177,37 @@ uint32_t SleepHandler::scheduledTicksLeft() {
   if ((SCIRQS & (1 << IRQSCP3)) || timer_match)
     return 0;
   return left;
+}
+
+// TODO take a few ticks off the schedule as it takes us some amount of
+// time to service the interrupt, mark the flag, get around to the loop
+// and wake the radio
+void SleepHandler::sleepRadio(uint32_t ms) {
+
+  uint32_t ticks = msToTicks(ms);
+
+  // Make sure we cannot "miss" the compare match if a low timeout is
+  // passed (really only ms = 0, which is forbidden, but handle it
+  // anyway).
+  if (ticks < 2) ticks = 2;
+  // Disable interrupts to prevent the counter passing the target before
+  // we clear the IRQSCP3 flag (due to other interrupts happening)
+  ATOMIC_BLOCK(ATOMIC_RESTORESTATE) {
+    // Schedule SCNT_CMP2 when the given counter is reached
+    write_scocr2(read_sccnt() + ticks);
+
+    // Clear any previously pending interrupt
+    SCIRQS = (1 << IRQSCP2);
+
+    // Enable the SCNT_CMP2 interrupt to wake us from sleep
+    SCIRQM |= (1 << IRQMCP2);
+  }
+
+  meshSleepStart = read_sccnt();
+
+  while (NWK_Busy()) {}
+
+  NWK_SleepReq();
 }
 
 void SleepHandler::doSleep(bool interruptible) {

--- a/src/SleepHandler.h
+++ b/src/SleepHandler.h
@@ -3,12 +3,19 @@
 
 #include "backpack-bus/Pbbe.h"
 #include "util/Duration.h"
+#include "lwm/sys/sysTimer.h"
+#include "lwm/nwk/nwk.h"
 
 ISR(SCNT_OVFL_vect);
 
 class SleepHandler {
   public:
+
     static void setup();
+    static void loop();
+
+    static const Duration& meshsleeptime();
+    static void sleepRadio(uint32_t ms);
 
     // Schedule a sleep until the given number of ms from now. The sleep
     // actually starts when doSleep is called, but any delay between
@@ -77,6 +84,11 @@ class SleepHandler {
     }
 
   protected:
+
+    // The total time radio spent sleeping since startup
+    static Duration meshSleep;
+    static uint32_t meshSleepStart;
+
     // The time from startup to the most recent overflow
     static Duration lastOverflow;
     // The total time spent sleeping since startup
@@ -91,6 +103,7 @@ class SleepHandler {
     static bool sleepUntilMatch(bool interruptible);
     static uint32_t read_sccnt();
     static void write_scocr3(uint32_t val);
+    static void write_scocr2(uint32_t val);
     static uint32_t read_scocr3();
 
     // The symbol counter always runs at 62.5kHz (period 16μs). When running


### PR DESCRIPTION
Splitting mesh sleep out from radio sleep with the end goal being able to implement a mesh synchronization protocol

power.sleep2 should be called something else but for some reason Ive noticed bitlash cant understand certain terms. I tried power.sleepRadio and power.sleepRF and neither worked.. power.sleep2 worked and I left it there

Looking for feedback
