### PR TITLE
add timer.starta and timer.stopa to stop and start a systimer that calls a bitlash function

### DIFF
--- a/src/Scout.h
+++ b/src/Scout.h
@@ -68,6 +68,9 @@ class PinoccioScout : public PinoccioClass {
     bool factoryReset();
     void reboot();
 
+    void startTimerA(uint32_t ms, const char *func, bool continuous);
+    void stopTimerA();
+
     void startDigitalStateChangeEvents();
     void stopDigitalStateChangeEvents();
     void startAnalogStateChangeEvents();
@@ -143,6 +146,9 @@ class PinoccioScout : public PinoccioClass {
       PINMODE_INPUT_PULLUP = 2,
       PINMODE_PWM = 3,
     };
+
+    char * timerAFunction;
+
   protected:
     uint32_t lastIndicate = 0;
     void checkStateChange();
@@ -156,6 +162,8 @@ class PinoccioScout : public PinoccioClass {
     SYS_Timer_t digitalStateChangeTimer;
     SYS_Timer_t analogStateChangeTimer;
     SYS_Timer_t peripheralStateChangeTimer;
+
+    SYS_Timer_t timerA;
 
     bool sleepPending;
     // The original sleep time, used to pass to the callback and to

--- a/src/Shell.cpp
+++ b/src/Shell.cpp
@@ -481,6 +481,35 @@ static numvar powerWakeupPin(void) {
 *      RGB LED HANDLERS     *
 \****************************/
 
+static numvar startTimerA(void) {
+  if (!checkArgs(2, 3, F("usage: timer.starta(ms, \"function\", [continuous])"))) {
+    return 0;
+  }
+
+  const char *func = NULL;
+  if (isstringarg(2))
+    func = (const char*)getarg(2);
+  else
+    func = keyGet(getarg(2));
+  
+  bool periodic = getarg(0) == 3 ? getarg(3) : 0;
+
+  if (func && !Shell.defined(func)) {
+    sp("Must be the name of function: ");
+    speol(func);
+    return 0;
+  }
+
+  Scout.startTimerA(getarg(1), func, periodic);
+  return 1;
+}
+
+static numvar stopTimerA(void) {
+
+  Scout.stopTimerA();
+  return 1;
+}
+
 static StringBuffer ledReportHQ(void) {
   StringBuffer report(100);
   report.appendSprintf("[%d,[%d,%d],[[%d,%d,%d],[%d,%d,%d]]]",
@@ -2527,6 +2556,9 @@ void PinoccioShell::setup() {
   addFunction("events.stop", stopStateChangeEvents);
   addFunction("events.setcycle", setEventCycle);
   addFunction("events.verbose", setEventVerbose);
+
+  addFunction("timer.starta", startTimerA);
+  addFunction("timer.stopa", stopTimerA);
 
   addFunction("key", keyMap);
   addFunction("key.free", keyFree);


### PR DESCRIPTION
Im actually not using built in reports because I dont need all that data or all those cycles
Im collapsing what I need into a command.report instead, but theres no way to schedule things from bitlash, so I made this and I think it might be handy.

timer.starta(10000,"power.report",1);
timer.stopa

went with letters instead of numbers to not confuse with timer0, timer1 etc on arduino

I actually kind of like this for the events system too. Then if you events.stop you actually get those 3 timers back too. 