### PR TITLE
Add category to library.properties

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -4,5 +4,6 @@ author=Pinoccio
 maintainer=Matthijs Kooijman <matthijs@stdin.nl>
 sentence=Various support code for the Pinoccio Scout boards
 paragraph=This library ties together the various parts of a Pinoccio Scout and forms to core of the default sketch running on these boards.
+category=Other
 url=https://github.com/Pinoccio/library-pinoccio
 architectures=avr


### PR DESCRIPTION
Fixes the `WARNING: Category '' in library Pinoccio is not valid. Setting to 'Uncategorized'` warning in Arduino IDE 1.6.6.
